### PR TITLE
ISubscribeToAsync<> usage and misc modernization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
 /.vs
+/.idea/

--- a/Seq.App.Azure.DevOps.sln.DotSettings
+++ b/Seq.App.Azure.DevOps.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=VSTS/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Seq.App.Azure.DevOps/Properties/launchSettings.json
+++ b/src/Seq.App.Azure.DevOps/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "Run": {
       "commandName": "Executable",
       "executablePath": "seqcli",
-      "commandLineArgs": "app run -d $(TargetDir) -p ApiKey=thisisatest"
+      "commandLineArgs": "app run -d $(TargetDir) -p ApiKey=thisisatest -p DescriptionDevOpsMappingField=System.Description -p AzureDevOpsUrl=https://localhost/azuredevops -p DevOpsIssueType=Bug -p Project=https://localhost/project -p PersonalAccessToken=12345 -p DebugMode=True"
     }
   }
 }

--- a/src/Seq.App.Azure.DevOps/Seq.App.Azure.DevOps.csproj
+++ b/src/Seq.App.Azure.DevOps/Seq.App.Azure.DevOps.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0</TargetFrameworks>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <VersionPrefix>1.0.0</VersionPrefix>
         <Description>An app for Seq (https://getseq.net) that forwards events to Azure DevOps (VSTS / TFS)</Description>
         <Authors>xantari, delubear</Authors>


### PR DESCRIPTION
Builds on `xantari/Seq.App>Azure.DevOps/netstandard2`. I think all the fixes are from that branch - I get this far running under Docker now:

![image](https://user-images.githubusercontent.com/342712/100167006-bf8f9000-2f09-11eb-8524-acd0366ea2d0.png)

I'm not signed up for Azure DevOps; I think this indicates "success" :-)

There is a bit of a "gotcha" that is probably confusing matters - the F5 experience with `seqcli` doesn't work with this app. The app needs to be published (e.g. by running `build.ps1`) in order for the pesky dependencies to be copied locally. My MSBuild skills aren't currently adequate to get around this, but hopefully it's a solvable problem.

I took a few liberties in the codebase while digging around - there's now an `ISubscribeToAsync<>` that fits well with using async APIs, and while finding my way through I let Rider weed out some unused code/inconsistent whitespace/older C# constructs. Hope I didn't take this too far :-)